### PR TITLE
Make height of shinyframe responsive

### DIFF
--- a/src/main/resources/templates/app.html
+++ b/src/main/resources/templates/app.html
@@ -18,8 +18,11 @@
 	<!-- content -->
     <iframe id="shinyframe" th:src="${container}" width="100%" style="margin-top: 50px; border: 0px;"></iframe>
 	<script type="text/javascript" th:inline="javascript"> 
-		$('#shinyframe').css('height', ($(window).height()-50)+'px');
-		
+		function setShinyframeHeight(){
+                    $('#shinyframe').css('height', ($(window).height()-50)+'px');
+                }
+                window.addEventListener("load", setShinyframeHeight);
+                window.addEventListener("resize",  setShinyframeHeight);		
 		function heartbeat() {
 		    setTimeout(function() {
 		        $.ajax("/heartbeat" + window.location.pathname).success(function(data) {


### PR DESCRIPTION
Add event listeners on load and resize events in order to set 
the height of the shinyframe iframe.